### PR TITLE
Fixes pagination in Get-GroupMembers and prevents duplicate entries in the report

### DIFF
--- a/IntuneRBAC.ps1
+++ b/IntuneRBAC.ps1
@@ -156,29 +156,31 @@ function Get-RoleMembers {
 
   $members = @()
   foreach ($member in $response) {
-    $groupId = $member.members -join ", " # Assuming there's only one group per member
+    #$groupId = $member.members -join ", " # Assuming there's only one group per member
 
-    # Skip if no group ID
-    if ([string]::IsNullOrEmpty($groupId)) {
-      continue
-    }
+    foreach ($group in $member.members) {
+      $groupId = $group
+      # Skip if no group ID
+      if ([string]::IsNullOrEmpty($groupId)) {
+        continue
+      }
 
-    # Fetch the group name
-    $groupUri = "https://graph.microsoft.com/beta/groups/$groupId"
-    try {
-      $groupResponse = Invoke-MgGraphRequest -Uri $groupUri -Method GET
-      $groupName = $groupResponse.displayName
-    }
-    catch {
-      Write-Warning "Group $groupId not found or inaccessible. Skipping."
-      continue
-    }
-
-    $members += [PSCustomObject]@{
-      RoleAssignmentName = $member.displayName
-      RoleAssignmentId   = $member.id
-      GroupId            = $groupId
-      GroupName          = $groupName
+      # Fetch the group name
+      $groupUri = "https://graph.microsoft.com/beta/groups/$groupId"
+      try {
+        $groupResponse = Invoke-MgGraphRequest -Uri $groupUri -Method GET
+        $groupName = $groupResponse.displayName
+      }
+      catch {
+        Write-Warning "Group $groupId not found or inaccessible. Skipping."
+        continue
+      }
+      $members += [PSCustomObject]@{
+        RoleAssignmentName = $member.displayName
+        RoleAssignmentId   = $member.id
+        GroupId            = $groupId
+        GroupName          = $groupName 
+      }
     }
   }
 
@@ -186,35 +188,35 @@ function Get-RoleMembers {
 }
 
 function Get-GroupMembers {
-    param($groupId, $nextLink)
+  param($groupId, $nextLink)
     
-    # Skip if no group ID provided
-    if ([string]::IsNullOrEmpty($groupId)) {
-        return @()
-    }
+  # Skip if no group ID provided
+  if ([string]::IsNullOrEmpty($groupId)) {
+    return @()
+  }
     
-    if ($nextLink) {
-        $groupMembersUri = $nextLink
-    }
-    else {
-        $groupMembersUri = "https://graph.microsoft.com/beta/groups/$groupId/members?`$select=id,userPrincipalName"
-    }
+  if ($nextLink) {
+    $groupMembersUri = $nextLink
+  }
+  else {
+    $groupMembersUri = "https://graph.microsoft.com/beta/groups/$groupId/members?`$select=id,userPrincipalName"
+  }
 
-    try {
-        $response = Invoke-MgGraphRequest -Uri $groupMembersUri -Method GET
-    }
-    catch {
-        Write-Warning "Could not fetch members for group ${groupId}: $($_.Exception.Message)"
-        return @()
-    }
+  try {
+    $response = Invoke-MgGraphRequest -Uri $groupMembersUri -Method GET
+  }
+  catch {
+    Write-Warning "Could not fetch members for group ${groupId}: $($_.Exception.Message)"
+    return @()
+  }
     
-    $upns += $response.value.userPrincipalName
+  $upns += $response.value.userPrincipalName
     
-    # Check for pagination
-    if ($response.'@odata.nextLink') {
-        $upns += Get-GroupMembers -groupId $groupId -nextLink $response.'@odata.nextLink'
-    }
-    return $upns
+  # Check for pagination
+  if ($response.'@odata.nextLink') {
+    $upns += Get-GroupMembers -groupId $groupId -nextLink $response.'@odata.nextLink'
+  }
+  return $upns
 }
 
 function Get-ScopeTags {

--- a/IntuneRBAC.ps1
+++ b/IntuneRBAC.ps1
@@ -199,7 +199,7 @@ function Get-GroupMembers {
     $groupMembersUri = $nextLink
   }
   else {
-    $groupMembersUri = "https://graph.microsoft.com/beta/groups/$groupId/members?`$select=id,userPrincipalName"
+    $groupMembersUri = "https://graph.microsoft.com/beta/groups/$groupId/transitiveMembers?`$select=id,userPrincipalName"
   }
 
   try {

--- a/IntuneRBAC.ps1
+++ b/IntuneRBAC.ps1
@@ -186,68 +186,35 @@ function Get-RoleMembers {
 }
 
 function Get-GroupMembers {
-  param($groupId)
-
-  # Skip if no group ID provided
-  if ([string]::IsNullOrEmpty($groupId)) {
-    return @()
-  }
-
-  $groupMembersUri = "https://graph.microsoft.com/beta/groups/$groupId/members"
-  try {
-    $response = Invoke-MgGraphRequest -Uri $groupMembersUri -Method GET
-  }
-  catch {
-    Write-Warning "Could not fetch members for group ${groupId}: $($_.Exception.Message)"
-    return @()
-  }
-
-  $userIds = @()
-  foreach ($member in $response.value) {
-    if ($member.id) {
-      $userIds += $member.id
+    param($groupId, $nextLink)
+    
+    # Skip if no group ID provided
+    if ([string]::IsNullOrEmpty($groupId)) {
+        return @()
     }
-  }
-
-  # Check for pagination
-  if ($response.'@odata.nextLink') {
-    $userIds += Get-GroupMembers -groupId $groupId
-  }
-
-  # Use parallel processing for user lookups if there are many users
-  if ($userIds.Count -gt 10) {
-    $upns = $userIds | ForEach-Object -Parallel {
-      $userId = $_
-      $userUri = "https://graph.microsoft.com/beta/users/$userId"
-      try {
-        $userResponse = Invoke-MgGraphRequest -Uri $userUri -Method GET
-        if ($userResponse.userPrincipalName) {
-          $userResponse.userPrincipalName
-        }
-      }
-      catch {
-        Write-Warning "Could not fetch user details for ${userId}: $($_.Exception.Message)"
-      }
-    } -ThrottleLimit 5
-  }
-  else {
-    # Sequential processing for small groups
-    $upns = @()
-    foreach ($userId in $userIds) {
-      $userUri = "https://graph.microsoft.com/beta/users/$userId"
-      try {
-        $userResponse = Invoke-MgGraphRequest -Uri $userUri -Method GET
-        if ($userResponse.userPrincipalName) {
-          $upns += $userResponse.userPrincipalName
-        }
-      }
-      catch {
-        Write-Warning "Could not fetch user details for ${userId}: $($_.Exception.Message)"
-      }
+    
+    if ($nextLink) {
+        $groupMembersUri = $nextLink
     }
-  }
+    else {
+        $groupMembersUri = "https://graph.microsoft.com/beta/groups/$groupId/members?`$select=id,userPrincipalName"
+    }
 
-  return $upns
+    try {
+        $response = Invoke-MgGraphRequest -Uri $groupMembersUri -Method GET
+    }
+    catch {
+        Write-Warning "Could not fetch members for group ${groupId}: $($_.Exception.Message)"
+        return @()
+    }
+    
+    $upns += $response.value.userPrincipalName
+    
+    # Check for pagination
+    if ($response.'@odata.nextLink') {
+        $upns += Get-GroupMembers -groupId $groupId -nextLink $response.'@odata.nextLink'
+    }
+    return $upns
 }
 
 function Get-ScopeTags {

--- a/IntuneRBAC.ps1
+++ b/IntuneRBAC.ps1
@@ -741,6 +741,7 @@ function Get-RolesWithScopeTags {
       [void]$htmlBuilder.Append("<div class='panel-top-section'>")
       [void]$htmlBuilder.Append("<h3><i class='fas fa-users'></i>Role Assignments</h3>")
       foreach ($assignment in $roleAssignments) {
+        $upns = @()
         $roleMembers = Get-RoleMembers -roleDefinitionId $assignment.RoleDefinitionId
         foreach ($member in $roleMembers) {
           $groupMembers = Get-GroupMembers -groupId $member.GroupId


### PR DESCRIPTION
I overlooked the previous PR #7 by @lousimonetti — apologies for that.

- This version of `Get-GroupMembers` may offer slightly better performance by calling the API with a `select` on `userPrincipalName`.
- Gets nested group members
- It also clears the `$upns` variable, preventing member accumulation and ensuring accurate reporting.
- Fix when multiple groups are assigned in the role assignment